### PR TITLE
Add inline support 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["Mailgun"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/vapor.git"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "3.3.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Mailgun/Models/Message.swift
+++ b/Sources/Mailgun/Models/Message.swift
@@ -15,12 +15,13 @@ extension Mailgun {
         public let text: String
         public let html: String?
         public let attachment: [File]?
+        public let inline: [File]?
         
         private enum CodingKeys : String, CodingKey {
-            case from, to, replyTo = "h:Reply-To", cc, bcc, subject, text, html, attachment
+            case from, to, replyTo = "h:Reply-To", cc, bcc, subject, text, html, attachment, inline
         }
         
-        public init(from: String, to: String, replyTo: String? = nil, cc: String? = nil, bcc: String? = nil, subject: String, text: String, html: String? = nil, attachments: [File]? = nil) {
+        public init(from: String, to: String, replyTo: String? = nil, cc: String? = nil, bcc: String? = nil, subject: String, text: String, html: String? = nil, attachments: [File]? = nil, inline: [File]? = nil) {
             self.from = from
             self.to = to
             self.replyTo = replyTo
@@ -30,9 +31,10 @@ extension Mailgun {
             self.text = text
             self.html = html
             self.attachment = attachments
+            self.inline = inline
         }
         
-        public init(from: String, to: [String], replyTo: String? = nil, cc: [String]? = nil, bcc: [String]? = nil, subject: String, text: String, html: String? = nil, attachments: [File]? = nil) {
+        public init(from: String, to: [String], replyTo: String? = nil, cc: [String]? = nil, bcc: [String]? = nil, subject: String, text: String, html: String? = nil, attachments: [File]? = nil, inline: [File]? = nil) {
             self.from = from
             self.to = to.joined(separator: ",")
             self.replyTo = replyTo
@@ -42,9 +44,10 @@ extension Mailgun {
             self.text = text
             self.html = html
             self.attachment = attachments
+            self.inline = inline
         }
         
-        public init(from: String, to: [FullEmail], replyTo: String? = nil, cc: [FullEmail]? = nil, bcc: [FullEmail]? = nil, subject: String, text: String, html: String? = nil, attachments: [File]? = nil) {
+        public init(from: String, to: [FullEmail], replyTo: String? = nil, cc: [FullEmail]? = nil, bcc: [FullEmail]? = nil, subject: String, text: String, html: String? = nil, attachments: [File]? = nil, inline: [File]? = nil) {
             self.from = from
             self.to = to.stringArray.joined(separator: ",")
             self.replyTo = replyTo
@@ -54,6 +57,7 @@ extension Mailgun {
             self.text = text
             self.html = html
             self.attachment = attachments
+            self.inline = inline
         }
     }
 }


### PR DESCRIPTION
https://documentation.mailgun.com/en/latest/user_manual.html#sending-via-api

This allows for emails to contain inline images. It works the same as attachments. The only thing to do was to add the inline field to Mailgun.Message. I tested and it works.