### PR TITLE
Add support for region selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Make sure you get an API key and register a custom domain
 In `configure.swift`:
 
 ```swift
-let mailgun = Mailgun(apiKey: "<api key>", domain: "mg.example.com")
+let mailgun = Mailgun(apiKey: "<api key>", domain: "mg.example.com", region: .eu)
 services.register(mailgun, as: Mailgun.self)
 ```
 


### PR DESCRIPTION
This PR adds the ability to select the region (EU or US) for mailgun in the initializer for `Mailgun`

`let mailgun = Mailgun(apiKey: "<api key>", domain: "mg.example.com", region: .eu)`

This implementation is pretty simple, not sure if it is the best. But hey, I made an effort! Please feel free to improve it.

This fixes issue #30 